### PR TITLE
Canonical capitalization: Ogg

### DIFF
--- a/public/tests/support-format-ogg.js
+++ b/public/tests/support-format-ogg.js
@@ -1,6 +1,6 @@
 ({
   name: 'support-format-ogg',
-  description: 'Supports OGG format',
+  description: 'Supports Ogg format',
   reports: {
     safari: {
       desc: 'Bug 42750 - Live OGG streaming using HTML5 audio or video tag does not work ',


### PR DESCRIPTION
See http://en.wikipedia.org/wiki/Ogg

(this was lost in 2a3bb1ff9c6d430ab7fdfa1f6419d6edfe127acf)
