### PR TITLE
Adding a test for "ended" event after hotswapping

### DIFF
--- a/public/tests/event-ended-after-hotswapping.js
+++ b/public/tests/event-ended-after-hotswapping.js
@@ -1,0 +1,28 @@
+({
+  name: 'event-ended-after-hotswapping',
+  description: 'Event "ended" after hotswapping',
+  spec: 'http://dev.w3.org/html5/spec/the-iframe-element.html#event-media-ended',
+  assert: function(finish) {
+    var
+      audio = this.audio,
+      i = 3, timer, timeout = 3000;
+
+    audio.addEventListener('ended', function() {
+      window.clearTimeout(timer);
+
+      if (--i) {
+        audio.src = AWPY.sound.mini.stream_url();
+      } else {
+        finish(true);
+      }
+    }, false);
+
+    audio.addEventListener('playing', function() {
+      timer = window.setTimeout(function() { finish(false); }, timeout);
+    }, false);
+
+    audio.autoplay = true;
+    audio.muted = true;
+    audio.src = AWPY.sound.mini.stream_url();
+  }
+})


### PR DESCRIPTION
Webkit has a bug affecting the "ended" event
(https://bugs.webkit.org/show_bug.cgi?id=61336). This test point it
out. Note this bug affect only "old" webkit version since the bug is
fixed. Although, the current Safari version (5.1.2) is still affected.
