### PR TITLE
Added tests for seeking using specific codecs

### DIFF
--- a/public/js/awpy.js
+++ b/public/js/awpy.js
@@ -115,8 +115,8 @@ AWPY.sound = (function() {
   };
 
   Object.keys(sounds).forEach(function(type) {
-    sounds[type].stream_url = function(cache) {
-      return 'http://areweplayingyet.herokuapp.com/sounds/' + type + '.' + AWPY.config.codec + (cache ? '' : '?' + (Math.random() * 1e9 | 0));
+    sounds[type].stream_url = function(cache, codec_type) {
+      return 'http://areweplayingyet.herokuapp.com/sounds/' + type + '.' + (codec_type ? codec_type : AWPY.config.codec) + (cache ? '' : '?' + (Math.random() * 1e9 | 0));
     };
   });
 

--- a/public/tests/support-seeking-unbuffered-position-aac.js
+++ b/public/tests/support-seeking-unbuffered-position-aac.js
@@ -36,7 +36,6 @@
 
     audio.preload = 'metadata';
     //Override default config with specific codec
-    AWPY.config.codec = "aac";
-    audio.src = AWPY.sound.long.stream_url();
+    audio.src = AWPY.sound.long.stream_url(false, 'aac');
   }
 })

--- a/public/tests/support-seeking-unbuffered-position-mp3.js
+++ b/public/tests/support-seeking-unbuffered-position-mp3.js
@@ -36,7 +36,6 @@
 
     audio.preload = 'metadata';
     //Override default config with specific codec
-    AWPY.config.codec = "mp3";
-    audio.src = AWPY.sound.long.stream_url();
+    audio.src = AWPY.sound.long.stream_url(false, 'mp3');
   }
 })

--- a/public/tests/support-seeking-unbuffered-position-ogg.js
+++ b/public/tests/support-seeking-unbuffered-position-ogg.js
@@ -36,7 +36,6 @@
 
     audio.preload = 'metadata';
     //Override default config with specific codec
-    AWPY.config.codec = "ogg";
-    audio.src = AWPY.sound.long.stream_url();
+    audio.src = AWPY.sound.long.stream_url(false, 'ogg');
   }
 })


### PR DESCRIPTION
We default to certain codecs while testing support-seeking-unbuffered-position (e.g., mp3 on chrome). This causes Chrome to fail this test.
However, I have tested it out and it actually performs properly using ogg or aac so I see the need to introduce separate tests for this.

One "interesting" thing that I see here... I have replace the long.mp3 (mono, 11Khz, 32bit samples) for another mp3 (stereo, 44kHz, 32bit samples) and it seems to have a different behavior...
For the long.mp3 there is a unique request with range 0- which never gets cancelled....
For the new.mp3 (only done locally) I see more requests done on the browser but it still tries to download the whole file... trying to figure out why.

 I will continue investigating what can be done on chrome and update http://code.google.com/p/chromium/issues/detail?id=100303 
