### PR TITLE
Fixes spec url of the timeupdate event

### DIFF
--- a/public/tests/event-timeupdate.js
+++ b/public/tests/event-timeupdate.js
@@ -1,7 +1,7 @@
 ({
   name: 'event-timeupdate',
   description: 'Event "timeupdate"',
-  spec: 'http://dev.w3.org/html5/spec/the-iframe-element.html#event-media-timeupdate',
+  spec: 'http://dev.w3.org/html5/spec/media-elements.html#event-media-timeupdate',
   assert: function(finish) {
     var audio = this.audio;
 


### PR DESCRIPTION
The url to the timeupdate event spec is wrong. It should be http://dev.w3.org/html5/spec/media-elements.html#event-media-timeupdate , not http://dev.w3.org/html5/spec/the-iframe-element.html#event-media-timeupdate
